### PR TITLE
docs: add badges and branding footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # YendorSupport
 
+<!-- Badges: Row 1 — Identity -->
+[![Atypical-Consulting - YendorSupport](https://img.shields.io/static/v1?label=Atypical-Consulting&message=YendorSupport&color=blue&logo=github)](https://github.com/Atypical-Consulting/YendorSupport)
+[![stars - YendorSupport](https://img.shields.io/github/stars/Atypical-Consulting/YendorSupport?style=social)](https://github.com/Atypical-Consulting/YendorSupport)
+[![forks - YendorSupport](https://img.shields.io/github/forks/Atypical-Consulting/YendorSupport?style=social)](https://github.com/Atypical-Consulting/YendorSupport)
+
+<!-- Badges: Row 2 — Activity -->
+[![issues - YendorSupport](https://img.shields.io/github/issues/Atypical-Consulting/YendorSupport)](https://github.com/Atypical-Consulting/YendorSupport/issues)
+[![GitHub pull requests](https://img.shields.io/github/issues-pr/Atypical-Consulting/YendorSupport)](https://github.com/Atypical-Consulting/YendorSupport/pulls)
+[![GitHub last commit](https://img.shields.io/github/last-commit/Atypical-Consulting/YendorSupport)](https://github.com/Atypical-Consulting/YendorSupport/commits/main)
+
 Marketing site, privacy policy, and support hub for [Yendor](https://apps.apple.com/app/yendor/id6746498844) — a faithful reimplementation of the classic roguelike Rogue 5.4.4.
 
 ## Links
@@ -28,3 +38,9 @@ Marketing site, privacy policy, and support hub for [Yendor](https://apps.apple.
 Yendor is built with Rust + Tauri 2 + React 19. It preserves every mechanic from the original 1980 Rogue while adding saga campaigns and pixel art visuals.
 
 Developed by [phmatray](https://github.com/phmatray) at [Atypical Consulting](https://github.com/Atypical-Consulting).
+
+---
+
+Built with care by [Atypical Consulting](https://atypical.garry-ai.cloud) — opinionated, production-grade open source.
+
+[![Contributors](https://contrib.rocks/image?repo=Atypical-Consulting/YendorSupport)](https://github.com/Atypical-Consulting/YendorSupport/graphs/contributors)


### PR DESCRIPTION
## Summary
- Add badge wall (org link, stars, forks, issues, PRs, last commit) at the top of README
- Add Atypical Consulting branding footer with contributors image at the bottom

## Notes
- Light-touch update: all existing content preserved as-is
- No LICENSE file exists, so license badge was omitted
- Build/coverage/distribution badges skipped (support/marketing repo)